### PR TITLE
Allow 4 parents classes

### DIFF
--- a/phpmd/phpmd.xml
+++ b/phpmd/phpmd.xml
@@ -80,7 +80,7 @@
     </rule>
     <rule ref="rulesets/design.xml/DepthOfInheritance">
         <properties>
-            <property name="minimum" value="3" description="Maximum number of acceptable parent classes." />
+            <property name="minimum" value="4" description="Maximum number of acceptable parent classes." />
         </properties>
     </rule>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">


### PR DESCRIPTION
On lumen JSON API controllers have 2 parents (PHP MD return 3...)