### PR TITLE
Update maximum coupling between object phpmd threshold

### DIFF
--- a/phpmd/phpmd.xml
+++ b/phpmd/phpmd.xml
@@ -85,7 +85,7 @@
     </rule>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">
         <properties>
-            <property name="minimum" value="11" description="Maximum number of acceptable dependencies." />
+            <property name="minimum" value="14" description="Maximum number of acceptable dependencies." />
         </properties>
     </rule>
 


### PR DESCRIPTION
Acording to this article, i want to level up this metric to 14. https://pdepend.org/documentation/software-metrics/coupling-between-objects.html
I met many cases where the value 11 is too low for example this controller. https://github.com/iadvize/connectors-app/blob/INT-731-addAuthenticationValidationStep/src/IAdvize/Connectors/ConnectorsProxyApiBundle/Controller/ProductsListController.php

Code is pretty clear, this always can be improved but i think shortness of these controller actions are suffisient